### PR TITLE
Adding unzip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.unzip?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=188&branchName=master)
+
+# unzip
+
+UnZip is an extraction utility for archives compressed in .zip format (also called 'zipfiles').
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "unzip"

--- a/controls/unzip_test.rb
+++ b/controls/unzip_test.rb
@@ -1,0 +1,32 @@
+title 'Tests to confirm unzip works as expected'
+
+plan_name = input('plan_name', value: 'unzip')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-unzip' do
+  impact 1.0
+  title 'Ensure unzip works'
+  desc '
+  To test unzip we ensure that the extended help message is shown as expected:
+
+    $ unzip -hh
+    Extended Help for UnZip
+
+    See the UnZip Manual for more detailed help
+    ...
+  '
+  unzip_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe unzip_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  unzip_pkg_ident = unzip_pkg_ident.stdout.strip
+
+  describe command("#{unzip_pkg_ident}/bin/unzip -hh") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Extended Help for UnZip/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: unzip
+title: Habitat Core Plan unzip
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan unzip
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,61 @@
+pkg_name=unzip
+pkg_origin=core
+pkg_version=6.0
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+UnZip is an extraction utility for archives compressed in .zip format (also \
+called 'zipfiles').\
+"
+pkg_upstream_url="https://sourceforge.net/projects/infozip/"
+pkg_license=('Zlib')
+pkg_source="https://downloads.sourceforge.net/infozip/unzip60.tar.gz"
+pkg_shasum="036d96991646d0449ed0aa952e4fbe21b476ce994abc276e49d30e686708bd37"
+pkg_dirname=unzip60
+pkg_deps=(
+  core/bzip2
+  core/glibc
+)
+pkg_build_deps=(
+  core/gcc
+  core/make
+)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  DEFINES="-DACORN_FTYPE_NFS -DWILD_STOP_AT_DIR -DLARGE_FILE_SUPPORT \
+    -DUNICODE_SUPPORT -DUNICODE_WCHAR -DUTF8_MAYBE_NATIVE -DNO_LCHMOD \
+    -DDATE_FORMAT=DF_YMD -DUSE_BZIP2 -DNOMEMCPY -DNO_WORKING_ISPRINT"
+  make \
+    -f unix/Makefile \
+    prefix="${pkg_prefix}" \
+    D_USE_BZ2=-DUSE_BZIP2 \
+    L_BZ2=-lbz2 \
+    LF2="$LDFLAGS" \
+    CF="$CFLAGS $CPPFLAGS -I. $DEFINES" \
+    unzips
+}
+
+do_install() {
+  make -f unix/Makefile prefix="${pkg_prefix}" install
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/pkg-config
+    core/coreutils
+    core/sed
+    core/grep
+    core/diffutils
+    core/make
+    core/patch
+  )
+fi


### PR DESCRIPTION
Migration from core plans adding inspec tests:

```
Profile: Habitat Core Plan unzip (unzip)
Version: 0.1.0
Target:  docker://6c733e61fb4604df07de0e5d607df9534cf8c879409782da713cf31fb0c5854c

  ✔  core-plans-unzip: Ensure unzip works
     ✔  Command: `hab pkg path habskp/unzip` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/unzip` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/unzip/6.0/20200612123533/bin/unzip -hh` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/unzip/6.0/20200612123533/bin/unzip -hh` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/unzip/6.0/20200612123533/bin/unzip -hh` stdout is expected to match /Extended Help for UnZip/
     ✔  Command: `/hab/pkgs/habskp/unzip/6.0/20200612123533/bin/unzip -hh` stderr is expected to be empty


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 6 successful, 0 failures, 0 skipped
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
